### PR TITLE
The Deno Vue tutorial requires installing dependencies before running

### DIFF
--- a/runtime/tutorials/how_to_with_npm/vue.md
+++ b/runtime/tutorials/how_to_with_npm/vue.md
@@ -27,9 +27,12 @@ deno run -A npm:create-vite
 When prompted, give your app a name and select `Vue` from the offered frameworks
 and `TypeScript` as a variant.
 
-Once created, `cd` into your new project and run the following command to serve
-your new Vue.js app:
+Once created, `cd` into your new project and run the following command to install dependencies:
+```shell
+deno install
+```
 
+Then, run the following command to serve your new Vue.js app:
 ```shell
 deno task dev
 ```


### PR DESCRIPTION
On my machine, while running through the [Deno Vue](https://docs.deno.com/runtime/tutorials/how_to_with_npm/vue/) tutorial, I needed to run `deno install` (or `npm install`) before running `deno task dev` or I would get the following error:

```
Task dev vite
vite: command not found
```